### PR TITLE
Add repeat flag

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -17,4 +17,9 @@ pub struct Opts {
     /// If enabled, any IPv6 (AAAA) records in the configuration file are ignored.
     #[clap(action, long)]
     pub skip_ipv6: bool,
+    /// Repeat after specified delay
+    ///
+    /// If enabled waits for the given delay between updating DNS records
+    #[clap(long)]
+    pub repeat: Option<u64>,
 }


### PR DESCRIPTION
Hey, thanks for your work.
Pull request to add a repeat flag. The repeat flag (--repeat) would take a delay in seconds and rerun the main run function after the specified delay. 

After deploying your application with docker, I realized that this is meant to be run as a one-off service on a systemd timer or similar. However, in docker, we typically have a container that runs indefinitely and performs a task. Running the current application works, but stops the container and starts a new one every time the update finishes. The changes add a repeat flag that suspends the main thread until the specified delay has elapsed and then runs the update again.

This is implemented quite naively, so please check before merging.