### PR TITLE
Switch back to die-exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,10 +407,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "die-exit-2"
-version = "0.4.1"
+name = "die-exit"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f7e250373cb3609a25291e35550e1e90dda0be72abeaefb6830e9b8b8f2bb3"
+checksum = "38c7de4151fc657b3ef1c90aebd13b25d089166f1f8c1d0a7950ebdfe6499f49"
 
 [[package]]
 name = "diff"
@@ -657,7 +657,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "clap",
- "die-exit-2",
+ "die-exit",
  "directories",
  "futures",
  "governor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,12 @@ futures = "0.3"
 anyhow = "1.0"
 governor = "0.5"
 async-trait = "0.1"
-die-exit-2 = "0.4"
+die-exit = "0.4"
 
 [dev-dependencies]
 httpmock = "0.6"
 regex = "1.6"
 
-[dev-dependencies.die-exit-2]
+[dev-dependencies.die-exit]
 version = "0.4"
 features = ["test"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod config;
 mod gandi;
 mod ip_source;
 mod opts;
-use die_exit_2::*;
+use die_exit::*;
 
 /// 30 requests per minute, see https://api.gandi.net/docs/reference/
 const GANDI_RATE_LIMIT: u32 = 30;


### PR DESCRIPTION
We had temporarily moved to die-exit-2, a forked release, but the original project has made a release now!

closes #79 