### PR TITLE
Avoid multiple main versions & concurrently get ipv4 and ipv6 addresses

### DIFF
--- a/src/ip_source/icanhazip.rs
+++ b/src/ip_source/icanhazip.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use super::ip_source::IPSource;
 
-pub(crate) struct IPSourceIcanhazip {}
+pub(crate) struct IPSourceIcanhazip;
 
 async fn get_ip(api_url: &str) -> anyhow::Result<String> {
     let response = reqwest::get(api_url).await?;
@@ -12,14 +12,14 @@ async fn get_ip(api_url: &str) -> anyhow::Result<String> {
 
 #[async_trait]
 impl IPSource for IPSourceIcanhazip {
-    async fn get_ipv4() -> anyhow::Result<String> {
+    async fn get_ipv4(&self) -> anyhow::Result<String> {
         Ok(get_ip("https://ipv4.icanhazip.com")
             .await?
             // icanazip puts a newline at the end
             .trim()
             .to_string())
     }
-    async fn get_ipv6() -> anyhow::Result<String> {
+    async fn get_ipv6(&self) -> anyhow::Result<String> {
         Ok(get_ip("https://ipv6.icanhazip.com")
             .await?
             // icanazip puts a newline at the end
@@ -32,13 +32,15 @@ impl IPSource for IPSourceIcanhazip {
 mod tests {
     use regex::Regex;
 
-    use super::IPSource;
+    use crate::ip_source::ip_source::IPSource;
+
     use super::IPSourceIcanhazip;
 
     #[tokio::test]
     #[ignore]
     async fn ipv4_test() {
-        let ipv4 = IPSourceIcanhazip::get_ipv4()
+        let ipv4 = IPSourceIcanhazip
+            .get_ipv4()
             .await
             .expect("Failed to get the IP address");
         assert!(Regex::new(r"^\d+[.]\d+[.]\d+[.]\d+$")
@@ -49,7 +51,8 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn ipv6_test() {
-        let ipv6 = IPSourceIcanhazip::get_ipv6()
+        let ipv6 = IPSourceIcanhazip
+            .get_ipv6()
             .await
             .expect("Failed to get the IP address");
         assert!(Regex::new(r"^([0-9a-fA-F]*:){7}[0-9a-fA-F]*$")

--- a/src/ip_source/ip_source.rs
+++ b/src/ip_source/ip_source.rs
@@ -2,6 +2,6 @@ use async_trait::async_trait;
 
 #[async_trait]
 pub trait IPSource {
-    async fn get_ipv4() -> anyhow::Result<String>;
-    async fn get_ipv6() -> anyhow::Result<String>;
+    async fn get_ipv4(&self) -> anyhow::Result<String>;
+    async fn get_ipv6(&self) -> anyhow::Result<String>;
 }

--- a/src/ip_source/ipify.rs
+++ b/src/ip_source/ipify.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use super::ip_source::IPSource;
 
-pub(crate) struct IPSourceIpify {}
+pub(crate) struct IPSourceIpify;
 
 async fn get_ip(api_url: &str) -> anyhow::Result<String> {
     let response = reqwest::get(api_url).await?;
@@ -12,10 +12,10 @@ async fn get_ip(api_url: &str) -> anyhow::Result<String> {
 
 #[async_trait]
 impl IPSource for IPSourceIpify {
-    async fn get_ipv4() -> anyhow::Result<String> {
+    async fn get_ipv4(&self) -> anyhow::Result<String> {
         get_ip("https://api.ipify.org").await
     }
-    async fn get_ipv6() -> anyhow::Result<String> {
+    async fn get_ipv6(&self) -> anyhow::Result<String> {
         get_ip("https://api6.ipify.org").await
     }
 }
@@ -30,7 +30,8 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn ipv4_test() {
-        let ipv4 = IPSourceIpify::get_ipv4()
+        let ipv4 = IPSourceIpify
+            .get_ipv4()
             .await
             .expect("Failed to get the IP address");
         assert!(Regex::new(r"^\d+[.]\d+[.]\d+[.]\d+$")
@@ -41,7 +42,8 @@ mod tests {
     #[tokio::test]
     #[ignore]
     async fn ipv6_test() {
-        let ipv6 = IPSourceIpify::get_ipv6()
+        let ipv6 = IPSourceIpify
+            .get_ipv6()
             .await
             .expect("Failed to get the IP address");
         assert!(Regex::new(r"^([0-9a-fA-F]*:){7}[0-9a-fA-F]*$")

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,8 +43,7 @@ pub struct APIPayload {
 async fn run(base_url: &str, ip_source: &Box<dyn IPSource>, conf: &Config) -> anyhow::Result<()> {
     config::validate_config(conf).die_with(|error| format!("Invalid config: {}", error));
     println!("Finding out the IP address...");
-    let ipv4_result = ip_source.get_ipv4().await;
-    let ipv6_result = ip_source.get_ipv6().await;
+    let (ipv4_result, ipv6_result) = join!(ip_source.get_ipv4(), ip_source.get_ipv6());
     let ipv4 = ipv4_result.as_ref();
     let ipv6 = ipv6_result.as_ref();
     println!("Found these:");

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use ip_source::icanhazip::IPSourceIcanhazip;
 use reqwest::{header, Client, ClientBuilder, StatusCode};
 use serde::Serialize;
 use std::{num::NonZeroU32, sync::Arc, time::Duration};
+use tokio::join;
 use tokio::{self, task::JoinHandle, time::sleep};
 mod config;
 mod gandi;
@@ -39,11 +40,11 @@ pub struct APIPayload {
     pub rrset_ttl: u32,
 }
 
-async fn run<IP: IPSource>(base_url: &str, conf: &Config) -> anyhow::Result<()> {
+async fn run(base_url: &str, ip_source: &Box<dyn IPSource>, conf: &Config) -> anyhow::Result<()> {
     config::validate_config(conf).die_with(|error| format!("Invalid config: {}", error));
     println!("Finding out the IP address...");
-    let ipv4_result = IP::get_ipv4().await;
-    let ipv6_result = IP::get_ipv6().await;
+    let ipv4_result = ip_source.get_ipv4().await;
+    let ipv6_result = ip_source.get_ipv6().await;
     let ipv4 = ipv4_result.as_ref();
     let ipv6 = ipv6_result.as_ref();
     println!("Found these:");
@@ -136,10 +137,11 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn run_dispatch(conf: &Config) -> anyhow::Result<()> {
-    match conf.ip_source {
-        IPSourceName::Ipify => run::<IPSourceIpify>("https://api.gandi.net", conf).await,
-        IPSourceName::Icanhazip => run::<IPSourceIcanhazip>("https://api.gandi.net", conf).await,
-    }
+    let ip_source: Box<dyn IPSource> = match conf.ip_source {
+        IPSourceName::Ipify => Box::new(IPSourceIpify),
+        IPSourceName::Icanhazip => Box::new(IPSourceIcanhazip),
+    };
+    run("https://api.gandi.net", &ip_source, conf).await
 }
 
 #[cfg(test)]
@@ -151,14 +153,14 @@ mod tests {
     use httpmock::MockServer;
     use tokio::fs;
 
-    struct IPSourceMock {}
+    struct IPSourceMock;
 
     #[async_trait]
     impl IPSource for IPSourceMock {
-        async fn get_ipv4() -> anyhow::Result<String> {
+        async fn get_ipv4(&self) -> anyhow::Result<String> {
             Ok("192.168.0.0".to_string())
         }
-        async fn get_ipv6() -> anyhow::Result<String> {
+        async fn get_ipv6(&self) -> anyhow::Result<String> {
             Ok("fe80:0000:0208:74ff:feda:625c".to_string())
         }
     }
@@ -194,7 +196,8 @@ mod tests {
             ..Opts::default()
         };
         let conf = config::load_config(&opts).expect("Failed to load config");
-        run::<IPSourceMock>(server.base_url().as_str(), &conf)
+        let ip_source: Box<dyn IPSource> = Box::new(IPSourceMock);
+        run(server.base_url().as_str(), &ip_source, &conf)
             .await
             .expect("Failed when running the update");
 


### PR DESCRIPTION
2 small optimizations / cleanup:

- We now avoid having different versions of the main for different IP sources. We instead use a dyn object, which is absolutely fine because the functions on the trait get called a total of 2 times. The performance impact of this is completely undetectable, while it makes the code a bit cleaner.
- IPv4 and IPv6 addresses are fetched concurrently instead of one after the other. A small optimization, but this should speed up the updates by about one network roundtrip worth of time.