### PR TITLE
Implement thiserror and improve output formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,6 +666,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
+ "thiserror",
  "tokio",
  "toml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ anyhow = "1.0"
 governor = "0.5"
 async-trait = "0.1"
 die-exit = "0.4"
+thiserror = "1.0.38"
 
 [dev-dependencies]
 httpmock = "0.6"

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ pub enum ConfigError {
     Io(#[from] io::Error),
     #[error("Failed to parse config file: {0}")]
     Parse(#[from] toml::de::Error),
-    #[error("Entry {0} has invalid type {1}")]
+    #[error("Entry '{0}' has invalid type '{1}'")]
     Validation(String, String),
     #[error("Can't find config directory")]
     ConfigNotFound(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,24 @@
 use crate::opts;
 use directories::ProjectDirs;
 use serde::Deserialize;
-use std::fs;
 use std::path::PathBuf;
+use std::{fs, io};
+use thiserror::Error;
 
 fn default_types() -> Vec<String> {
     DEFAULT_TYPES.iter().map(|v| v.to_string()).collect()
+}
+
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("Failed to read config file: {0} ")]
+    Io(#[from] io::Error),
+    #[error("Failed to parse config file: {0}")]
+    Parse(#[from] toml::de::Error),
+    #[error("Entry {0} has invalid type {1}")]
+    Validation(String, String),
+    #[error("Can't find config directory")]
+    ConfigNotFound(),
 }
 
 #[derive(Deserialize, Debug)]
@@ -65,18 +78,20 @@ impl Config {
     }
 }
 
-fn load_config_from<P: std::convert::AsRef<std::path::Path>>(path: P) -> anyhow::Result<Config> {
+fn load_config_from<P: std::convert::AsRef<std::path::Path>>(
+    path: P,
+) -> Result<Config, ConfigError> {
     let contents = fs::read_to_string(path)?;
     Ok(toml::from_str(&contents)?)
 }
 
-pub fn load_config(opts: &opts::Opts) -> anyhow::Result<Config> {
+pub fn load_config(opts: &opts::Opts) -> Result<Config, ConfigError> {
     let mut config = match &opts.config {
         Some(config_path) => load_config_from(config_path),
         None => {
             let confpath = ProjectDirs::from("me", "kaangenc", "gandi-dynamic-dns")
                 .map(|dir| PathBuf::from(dir.config_dir()).join("config.toml"))
-                .ok_or_else(|| anyhow::anyhow!("Can't find config directory"));
+                .ok_or(ConfigError::ConfigNotFound());
             confpath
                 .and_then(|path| {
                     println!("Checking for config: {}", path.to_string_lossy());
@@ -105,11 +120,14 @@ pub fn load_config(opts: &opts::Opts) -> anyhow::Result<Config> {
     Ok(config)
 }
 
-pub fn validate_config(config: &Config) -> anyhow::Result<()> {
+pub fn validate_config(config: &Config) -> Result<(), ConfigError> {
     for entry in &config.entry {
         for entry_type in Config::types(entry) {
             if entry_type != "A" && entry_type != "AAAA" {
-                anyhow::bail!("Entry {} has invalid type {}", entry.name, entry_type);
+                return Err(ConfigError::Validation(
+                    entry.name.clone(),
+                    entry_type.to_string(),
+                ));
             }
         }
     }

--- a/src/ip_source/icanhazip.rs
+++ b/src/ip_source/icanhazip.rs
@@ -1,10 +1,12 @@
 use async_trait::async_trait;
 
+use crate::ClientError;
+
 use super::ip_source::IPSource;
 
 pub(crate) struct IPSourceIcanhazip;
 
-async fn get_ip(api_url: &str) -> anyhow::Result<String> {
+async fn get_ip(api_url: &str) -> Result<String, ClientError> {
     let response = reqwest::get(api_url).await?;
     let text = response.text().await?;
     Ok(text)
@@ -12,14 +14,14 @@ async fn get_ip(api_url: &str) -> anyhow::Result<String> {
 
 #[async_trait]
 impl IPSource for IPSourceIcanhazip {
-    async fn get_ipv4(&self) -> anyhow::Result<String> {
+    async fn get_ipv4(&self) -> Result<String, ClientError> {
         Ok(get_ip("https://ipv4.icanhazip.com")
             .await?
             // icanazip puts a newline at the end
             .trim()
             .to_string())
     }
-    async fn get_ipv6(&self) -> anyhow::Result<String> {
+    async fn get_ipv6(&self) -> Result<String, ClientError> {
         Ok(get_ip("https://ipv6.icanhazip.com")
             .await?
             // icanazip puts a newline at the end

--- a/src/ip_source/ip_source.rs
+++ b/src/ip_source/ip_source.rs
@@ -1,7 +1,9 @@
 use async_trait::async_trait;
 
+use crate::ClientError;
+
 #[async_trait]
 pub trait IPSource {
-    async fn get_ipv4(&self) -> anyhow::Result<String>;
-    async fn get_ipv6(&self) -> anyhow::Result<String>;
+    async fn get_ipv4(&self) -> Result<String, ClientError>;
+    async fn get_ipv6(&self) -> Result<String, ClientError>;
 }

--- a/src/ip_source/ipify.rs
+++ b/src/ip_source/ipify.rs
@@ -1,10 +1,12 @@
 use async_trait::async_trait;
 
+use crate::ClientError;
+
 use super::ip_source::IPSource;
 
 pub(crate) struct IPSourceIpify;
 
-async fn get_ip(api_url: &str) -> anyhow::Result<String> {
+async fn get_ip(api_url: &str) -> Result<String, ClientError> {
     let response = reqwest::get(api_url).await?;
     let text = response.text().await?;
     Ok(text)
@@ -12,10 +14,10 @@ async fn get_ip(api_url: &str) -> anyhow::Result<String> {
 
 #[async_trait]
 impl IPSource for IPSourceIpify {
-    async fn get_ipv4(&self) -> anyhow::Result<String> {
+    async fn get_ipv4(&self) -> Result<String, ClientError> {
         get_ip("https://api.ipify.org").await
     }
-    async fn get_ipv6(&self) -> anyhow::Result<String> {
+    async fn get_ipv6(&self) -> Result<String, ClientError> {
         get_ip("https://api6.ipify.org").await
     }
 }

--- a/src/ip_source/seeip.rs
+++ b/src/ip_source/seeip.rs
@@ -1,10 +1,12 @@
 use async_trait::async_trait;
 
+use crate::ClientError;
+
 use super::ip_source::IPSource;
 
 pub(crate) struct IPSourceSeeIP;
 
-async fn get_ip(api_url: &str) -> anyhow::Result<String> {
+async fn get_ip(api_url: &str) -> Result<String, ClientError> {
     let response = reqwest::get(api_url).await?;
     let text = response.text().await?;
     Ok(text)
@@ -12,10 +14,10 @@ async fn get_ip(api_url: &str) -> anyhow::Result<String> {
 
 #[async_trait]
 impl IPSource for IPSourceSeeIP {
-    async fn get_ipv4(&self) -> anyhow::Result<String> {
+    async fn get_ipv4(&self) -> Result<String, ClientError> {
         get_ip("https://ip4.seeip.org").await
     }
-    async fn get_ipv6(&self) -> anyhow::Result<String> {
+    async fn get_ipv6(&self) -> Result<String, ClientError> {
         get_ip("https://ip6.seeip.org").await
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,11 @@ use crate::config::Config;
 use crate::gandi::GandiAPI;
 use crate::ip_source::{ip_source::IPSource, ipify::IPSourceIpify};
 use clap::Parser;
-use config::IPSourceName;
+use config::{ConfigError, IPSourceName};
 use ip_source::icanhazip::IPSourceIcanhazip;
 use ip_source::seeip::IPSourceSeeIP;
 use opts::Opts;
+use reqwest::header::InvalidHeaderValue;
 use reqwest::{header, Client, ClientBuilder, StatusCode};
 use serde::Serialize;
 use std::{num::NonZeroU32, sync::Arc, time::Duration};
@@ -16,13 +17,44 @@ mod gandi;
 mod ip_source;
 mod opts;
 use die_exit::*;
+use thiserror::Error;
 
 /// 30 requests per minute, see https://api.gandi.net/docs/reference/
 const GANDI_RATE_LIMIT: u32 = 30;
 /// If we hit the rate limit, wait up to this many seconds before next attempt
 const GANDI_DELAY_JITTER: u64 = 20;
 
-fn api_client(api_key: &str) -> anyhow::Result<Client> {
+#[derive(Error, Debug)]
+pub enum ClientError {
+    #[error("Error occured while reading config: {0}")]
+    Config(#[from] ConfigError),
+    #[error("Error while accessing the Gandi API: {0}")]
+    Api(#[from] ApiError),
+    #[error("Error while converting the API key to a header: {0}")]
+    InvalidHeader(#[from] InvalidHeaderValue),
+    #[error("Error while sending request: {0}")]
+    Request(#[from] reqwest::Error),
+    #[error("Error while joining async tasks: {0}")]
+    TaskJoin(#[from] tokio::task::JoinError),
+    #[error("Unexpected type in config: {0}")]
+    BadEntry(String),
+    #[error("Entry '{0}' includes type A which requires an IPv4 adress but no IPv4 adress could be determined because: {1}")]
+    Ipv4missing(String, String),
+    #[error("Entry '{0}' includes type AAAA which requires an IPv6 adress but no IPv6 adress could be determined because: {1}")]
+    Ipv6missing(String, String),
+}
+
+#[derive(Error, Debug)]
+pub enum ApiError {
+    #[error("API returned 403 - Forbidden. Message: {message:?}")]
+    Forbidden { message: String },
+    #[error("API returned 403 - Unauthorized. Provided API key is possibly incorrect")]
+    Unauthorized(),
+    #[error("API returned {0} - {0}")]
+    Unknown(StatusCode, String),
+}
+
+fn api_client(api_key: &str) -> Result<Client, ClientError> {
     let client_builder = ClientBuilder::new();
 
     let key = format!("Apikey {}", api_key);
@@ -47,7 +79,7 @@ async fn run(
     ip_source: &Box<dyn IPSource>,
     conf: &Config,
     opts: &Opts,
-) -> anyhow::Result<()> {
+) -> Result<(), ClientError> {
     let mut last_ipv4: Option<String> = None;
     let mut last_ipv6: Option<String> = None;
 
@@ -100,10 +132,22 @@ async fn run(
                     }
                     .url();
                     let ip = match entry_type {
-                        "A" => ipv4.die_with(|error| format!("Needed IPv4 for {fqdn}: {error}")),
-                        "AAAA" => ipv6.die_with(|error| format!("Needed IPv6 for {fqdn}: {error}")),
-                        bad_entry_type => die!("Unexpected type in config: {}", bad_entry_type),
-                    };
+                        "A" => match ipv4 {
+                            Ok(ref value) => Ok(value),
+                            Err(ref err) => Err(ClientError::Ipv4missing(
+                                entry.name.clone(),
+                                err.to_string(),
+                            )),
+                        },
+                        "AAAA" => match ipv6 {
+                            Ok(ref value) => Ok(value),
+                            Err(ref err) => Err(ClientError::Ipv6missing(
+                                entry.name.clone(),
+                                err.to_string(),
+                            )),
+                        },
+                        &_ => Err(ClientError::BadEntry(entry_type.to_string())),
+                    }?;
                     let payload = APIPayload {
                         rrset_values: vec![ip.to_string()],
                         rrset_ttl: Config::ttl(entry, conf),
@@ -151,17 +195,16 @@ async fn run(
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> Result<(), ClientError> {
     let opts = opts::Opts::parse();
-    let conf = config::load_config(&opts)
-        .die_with(|error| format!("Failed to read config file: {}", error));
+    let conf = config::load_config(&opts)?;
 
     let ip_source: Box<dyn IPSource> = match conf.ip_source {
         IPSourceName::Ipify => Box::new(IPSourceIpify),
         IPSourceName::Icanhazip => Box::new(IPSourceIcanhazip),
         IPSourceName::SeeIP => Box::new(IPSourceSeeIP),
     };
-    config::validate_config(&conf).die_with(|error| format!("Invalid config: {}", error));
+    config::validate_config(&conf)?;
     run("https://api.gandi.net", &ip_source, &conf, &opts).await?;
     Ok(())
 }
@@ -170,7 +213,7 @@ async fn main() -> anyhow::Result<()> {
 mod tests {
     use std::{env::temp_dir, time::Duration};
 
-    use crate::{config, ip_source::ip_source::IPSource, opts::Opts, run};
+    use crate::{config, ip_source::ip_source::IPSource, opts::Opts, run, ClientError};
     use async_trait::async_trait;
     use httpmock::MockServer;
     use tokio::{fs, task::LocalSet, time::sleep};
@@ -179,10 +222,10 @@ mod tests {
 
     #[async_trait]
     impl IPSource for IPSourceMock {
-        async fn get_ipv4(&self) -> anyhow::Result<String> {
+        async fn get_ipv4(&self) -> Result<String, ClientError> {
             Ok("192.168.0.0".to_string())
         }
-        async fn get_ipv6(&self) -> anyhow::Result<String> {
+        async fn get_ipv6(&self) -> Result<String, ClientError> {
             Ok("fe80:0000:0208:74ff:feda:625c".to_string())
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,7 +264,7 @@ async fn run(
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), ClientError> {
+async fn main() -> anyhow::Result<()> {
     let opts = opts::Opts::parse();
     let conf = config::load_config(&opts)?;
 


### PR DESCRIPTION
Hey,

this PR implements the [`thiserror`](https://docs.rs/thiserror/latest/thiserror/) library for everything that used anyhow previously. `thiserror` implements a derive macro for the std::error::Error trait. I've introduced some Error enums to handle possible errors in a more structured way. This also allows us to just use the ? operator pretty much everywhere instead of .die or .die_with.

### Struct ApiError
Handles possible errors from the Gandi API such as Forbidden or Unauthorized. API Respone information was taken from [here](https://api.gandi.net/docs/livedns/).

### Struct ConfigError
Handles all errors that can occur while reading the config file, for example deserialization errors or validation errors.

### Struct ClientError
This is a kind of SuperError that can be created from ConfigErrors or ApiErrors. This just contains all possible errors and formatting for those errors for the end user.

The Error implementation with thiserror also allows for formatting of error messages, which is convenient. The output of the program was also improved, since now only successful requests are counted. The general output on success or error was also improved.

Please let me know if you have any comments on the implementation or if this PR can be further improved.

Related: #72 